### PR TITLE
feat: Add distinct handling for albums and single media

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ DESTINATION_CHANNEL=
 # Masukkan ID chat atau username tujuan untuk notifikasi error
 # Contoh: 123456789 (untuk user) atau 'username'
 NOTIFICATION_CHAT_ID=
+
+# [OPSIONAL] Atur ID pesan untuk mulai menyalin riwayat.
+# Jika tidak diatur, bot hanya akan memantau pesan baru.
+# Contoh: HISTORY_START_ID=500
+HISTORY_START_ID=


### PR DESCRIPTION
This commit refactors the event handling logic to correctly process both single media messages and albums (media groups).

- A new event handler using `events.Album` has been added to specifically capture and copy entire albums as a single grouped message.
- The existing `NewMessage` event handler has been modified to ignore messages that are part of an album, preventing duplicate processing.
- The retry logic for `FloodWaitError` is maintained for both handlers.