### PR TITLE
fix: Resolve InputEntity error on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -251,6 +251,12 @@ async def main():
     async with client:
         print("Bot berhasil terhubung.")
 
+        # Memuat dialog untuk "memanaskan" cache entitas dan mencegah error
+        print("Memuat dialog untuk caching entitas...")
+        async for _ in client.iter_dialogs():
+            pass
+        print("Dialogs berhasil di-cache.")
+
         # 1. Mulai percakapan interaktif dengan admin
         source_channel_id = None
         start_message_id = None


### PR DESCRIPTION
This commit fixes a `Could not find the input entity` error that occurred during the interactive setup phase.

The error was caused by Telethon's entity cache not being populated when the bot tried to find the admin user by their ID to start a conversation.

The fix is to iterate through the client's dialogs (`client.iter_dialogs()`) immediately after connecting. This standard practice "primes" the entity cache, ensuring that Telethon can resolve the admin's user ID and successfully initiate the conversation.