### PR TITLE
fix: Correct NameError in history scraping mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -207,7 +207,7 @@ async def scrape_history(client, source_entity, start_id):
 
         while True:
             print(f"\nMemulai pass pengejaran dari ID: {last_known_id + 1}")
-            latest_messages = await client.get_messages(entity, limit=1)
+            latest_messages = await client.get_messages(source_entity, limit=1)
             if not latest_messages:
                 print("Channel tampak kosong. Mengakhiri mode riwayat.")
                 break
@@ -218,13 +218,13 @@ async def scrape_history(client, source_entity, start_id):
                 break
 
             print(f"Menyalin pesan dari ID {last_known_id + 1} hingga {current_latest_id}...")
-            last_known_id = await run_scrape_pass(last_known_id, client, entity, processed_group_ids)
+            last_known_id = await run_scrape_pass(last_known_id, client, source_entity, processed_group_ids)
 
         print("\nSinkronisasi awal selesai. Menunggu 5 detik untuk 'settling'...")
         await asyncio.sleep(5)
 
         print("Melakukan satu pemeriksaan terakhir...")
-        final_pass_last_id = await run_scrape_pass(last_known_id, client, entity, processed_group_ids)
+        final_pass_last_id = await run_scrape_pass(last_known_id, client, source_entity, processed_group_ids)
         if final_pass_last_id > last_known_id:
             print("Sisa pesan berhasil disalin.")
         else:


### PR DESCRIPTION
This commit fixes a `NameError: name 'entity' is not defined` that occurred within the `scrape_history` function.

The error was caused by using the undefined variable `entity` instead of the correct function parameter `source_entity` when calling `client.get_messages` and the `run_scrape_pass` helper.

This has been corrected by replacing all instances of `entity` with `source_entity` inside the `scrape_history` function.